### PR TITLE
boards: fix afcv3_1 acq_chan address overlap.

### DIFF
--- a/src/boards/afcv3_1/acq_chan.c
+++ b/src/boards/afcv3_1/acq_chan.c
@@ -18,6 +18,15 @@
 /*                 Channels definitions               */
 /******************************************************/
 
+#define ACQ0_START 0x0
+#define ACQ0_END 0x10000000
+#define ACQ1_START 0x10000000
+#define ACQ1_END 0x20000000
+#define ACQ2_START 0x20000000
+#define ACQ2_END 0x30000000
+#define ACQ3_START 0x30000000
+#define ACQ3_END 0x40000000
+
 const size_t afcv3_1_num_acq_core_smios         = __NUM_ACQ_CORE_SMIOS;
 HUTILS_EXPORT_SYMBOL(const size_t *, const_size_t_p, afcv3_1_num_acq_core_smios);
 
@@ -38,372 +47,372 @@ const acq_buf_t afcv3_1_acq_buf[__NUM_ACQ_CORE_SMIOS][__END_CHAN_ID] = {
     {
         {
             .id = __ADC_CHAN_ID,
-            .start_addr = DDR3_ADC0_START_ADDR,
-            .end_addr = DDR3_ADC0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __ADCSWAP_CHAN_ID,
-            .start_addr = DDR3_ADCSWAP0_START_ADDR,
-            .end_addr = DDR3_ADCSWAP0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __MIXIQ_CHAN_ID,
-            .start_addr = DDR3_MIXIQ0_START_ADDR,
-            .end_addr = DDR3_MIXIQ0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __DUMMY0_CHAN_ID,
-            .start_addr = DDR3_DUMMY00_START_ADDR,
-            .end_addr = DDR3_DUMMY00_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __TBTDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_TBTDECIMIQ0_START_ADDR,
-            .end_addr = DDR3_TBTDECIMIQ0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __DUMMY1_CHAN_ID,
-            .start_addr = DDR3_DUMMY10_START_ADDR,
-            .end_addr = DDR3_DUMMY10_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __TBTAMP_CHAN_ID,
-            .start_addr = DDR3_TBTAMP0_START_ADDR,
-            .end_addr = DDR3_TBTAMP0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __TBTPHA_CHAN_ID,
-            .start_addr = DDR3_TBTPHA0_START_ADDR,
-            .end_addr = DDR3_TBTPHA0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __TBTPOS_CHAN_ID,
-            .start_addr = DDR3_TBTPOS0_START_ADDR,
-            .end_addr = DDR3_TBTPOS0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __FOFBDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_FOFBDECIMIQ0_START_ADDR,
-            .end_addr = DDR3_FOFBDECIMIQ0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __DUMMY2_CHAN_ID,
-            .start_addr = DDR3_DUMMY20_START_ADDR,
-            .end_addr = DDR3_DUMMY20_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __FOFBAMP_CHAN_ID,
-            .start_addr = DDR3_FOFBAMP0_START_ADDR,
-            .end_addr = DDR3_FOFBAMP0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __FOFBPHA_CHAN_ID,
-            .start_addr = DDR3_FOFBPHA0_START_ADDR,
-            .end_addr = DDR3_FOFBPHA0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __FOFBPOS_CHAN_ID,
-            .start_addr = DDR3_FOFBPOS0_START_ADDR,
-            .end_addr = DDR3_FOFBPOS0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __MONIT1AMP_CHAN_ID,
-            .start_addr = DDR3_MONIT1AMP0_START_ADDR,
-            .end_addr = DDR3_MONIT1AMP0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __MONIT1POS_CHAN_ID,
-            .start_addr = DDR3_MONIT1POS0_START_ADDR,
-            .end_addr = DDR3_MONIT1POS0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __MONITAMP_CHAN_ID,
-            .start_addr = DDR3_MONITAMP0_START_ADDR,
-            .end_addr = DDR3_MONITAMP0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
         {
             .id = __MONITPOS_CHAN_ID,
-            .start_addr = DDR3_MONITPOS0_START_ADDR,
-            .end_addr = DDR3_MONITPOS0_END_ADDR
+            .start_addr = ACQ0_START,
+            .end_addr = ACQ0_END
         },
     },
     /*** Acquisition Core 1 Channel Parameters ***/
     {
         {
             .id = __ADC_CHAN_ID,
-            .start_addr = DDR3_ADC1_START_ADDR,
-            .end_addr = DDR3_ADC1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __ADCSWAP_CHAN_ID,
-            .start_addr = DDR3_ADCSWAP1_START_ADDR,
-            .end_addr = DDR3_ADCSWAP1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __MIXIQ_CHAN_ID,
-            .start_addr = DDR3_MIXIQ1_START_ADDR,
-            .end_addr = DDR3_MIXIQ1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __DUMMY0_CHAN_ID,
-            .start_addr = DDR3_DUMMY01_START_ADDR,
-            .end_addr = DDR3_DUMMY01_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __TBTDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_TBTDECIMIQ1_START_ADDR,
-            .end_addr = DDR3_TBTDECIMIQ1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __DUMMY1_CHAN_ID,
-            .start_addr = DDR3_DUMMY11_START_ADDR,
-            .end_addr = DDR3_DUMMY11_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __TBTAMP_CHAN_ID,
-            .start_addr = DDR3_TBTAMP1_START_ADDR,
-            .end_addr = DDR3_TBTAMP1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __TBTPHA_CHAN_ID,
-            .start_addr = DDR3_TBTPHA1_START_ADDR,
-            .end_addr = DDR3_TBTPHA1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __TBTPOS_CHAN_ID,
-            .start_addr = DDR3_TBTPOS1_START_ADDR,
-            .end_addr = DDR3_TBTPOS1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __FOFBDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_FOFBDECIMIQ1_START_ADDR,
-            .end_addr = DDR3_FOFBDECIMIQ1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __DUMMY2_CHAN_ID,
-            .start_addr = DDR3_DUMMY21_START_ADDR,
-            .end_addr = DDR3_DUMMY21_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __FOFBAMP_CHAN_ID,
-            .start_addr = DDR3_FOFBAMP1_START_ADDR,
-            .end_addr = DDR3_FOFBAMP1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __FOFBPHA_CHAN_ID,
-            .start_addr = DDR3_FOFBPHA1_START_ADDR,
-            .end_addr = DDR3_FOFBPHA1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __FOFBPOS_CHAN_ID,
-            .start_addr = DDR3_FOFBPOS1_START_ADDR,
-            .end_addr = DDR3_FOFBPOS1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __MONIT1AMP_CHAN_ID,
-            .start_addr = DDR3_MONIT1AMP1_START_ADDR,
-            .end_addr = DDR3_MONIT1AMP1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __MONIT1POS_CHAN_ID,
-            .start_addr = DDR3_MONIT1POS1_START_ADDR,
-            .end_addr = DDR3_MONIT1POS1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __MONITAMP_CHAN_ID,
-            .start_addr = DDR3_MONITAMP1_START_ADDR,
-            .end_addr = DDR3_MONITAMP1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
         {
             .id = __MONITPOS_CHAN_ID,
-            .start_addr = DDR3_MONITPOS1_START_ADDR,
-            .end_addr = DDR3_MONITPOS1_END_ADDR
+            .start_addr = ACQ1_START,
+            .end_addr = ACQ1_END
         },
     },
     /*** Acquisition Core 2 Channel Parameters ***/
     {
         {
             .id = __ADC_CHAN_ID,
-            .start_addr = DDR3_ADC2_START_ADDR,
-            .end_addr = DDR3_ADC2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __ADCSWAP_CHAN_ID,
-            .start_addr = DDR3_ADCSWAP2_START_ADDR,
-            .end_addr = DDR3_ADCSWAP2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __MIXIQ_CHAN_ID,
-            .start_addr = DDR3_MIXIQ2_START_ADDR,
-            .end_addr = DDR3_MIXIQ2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __DUMMY0_CHAN_ID,
-            .start_addr = DDR3_DUMMY02_START_ADDR,
-            .end_addr = DDR3_DUMMY02_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __TBTDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_TBTDECIMIQ2_START_ADDR,
-            .end_addr = DDR3_TBTDECIMIQ2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __DUMMY1_CHAN_ID,
-            .start_addr = DDR3_DUMMY12_START_ADDR,
-            .end_addr = DDR3_DUMMY12_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __TBTAMP_CHAN_ID,
-            .start_addr = DDR3_TBTAMP2_START_ADDR,
-            .end_addr = DDR3_TBTAMP2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __TBTPHA_CHAN_ID,
-            .start_addr = DDR3_TBTPHA2_START_ADDR,
-            .end_addr = DDR3_TBTPHA2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __TBTPOS_CHAN_ID,
-            .start_addr = DDR3_TBTPOS2_START_ADDR,
-            .end_addr = DDR3_TBTPOS2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __FOFBDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_FOFBDECIMIQ2_START_ADDR,
-            .end_addr = DDR3_FOFBDECIMIQ2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __DUMMY2_CHAN_ID,
-            .start_addr = DDR3_DUMMY22_START_ADDR,
-            .end_addr = DDR3_DUMMY22_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __FOFBAMP_CHAN_ID,
-            .start_addr = DDR3_FOFBAMP2_START_ADDR,
-            .end_addr = DDR3_FOFBAMP2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __FOFBPHA_CHAN_ID,
-            .start_addr = DDR3_FOFBPHA2_START_ADDR,
-            .end_addr = DDR3_FOFBPHA2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __FOFBPOS_CHAN_ID,
-            .start_addr = DDR3_FOFBPOS2_START_ADDR,
-            .end_addr = DDR3_FOFBPOS2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __MONIT1AMP_CHAN_ID,
-            .start_addr = DDR3_MONIT1AMP2_START_ADDR,
-            .end_addr = DDR3_MONIT1AMP2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __MONIT1POS_CHAN_ID,
-            .start_addr = DDR3_MONIT1POS2_START_ADDR,
-            .end_addr = DDR3_MONIT1POS2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __MONITAMP_CHAN_ID,
-            .start_addr = DDR3_MONITAMP2_START_ADDR,
-            .end_addr = DDR3_MONITAMP2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
         {
             .id = __MONITPOS_CHAN_ID,
-            .start_addr = DDR3_MONITPOS2_START_ADDR,
-            .end_addr = DDR3_MONITPOS2_END_ADDR
+            .start_addr = ACQ2_START,
+            .end_addr = ACQ2_END
         },
     },
     /*** Acquisition Core 3 Channel Parameters ***/
     {
         {
             .id = __ADC_CHAN_ID,
-            .start_addr = DDR3_ADC3_START_ADDR,
-            .end_addr = DDR3_ADC3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __ADCSWAP_CHAN_ID,
-            .start_addr = DDR3_ADCSWAP3_START_ADDR,
-            .end_addr = DDR3_ADCSWAP3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __MIXIQ_CHAN_ID,
-            .start_addr = DDR3_MIXIQ3_START_ADDR,
-            .end_addr = DDR3_MIXIQ3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __DUMMY0_CHAN_ID,
-            .start_addr = DDR3_DUMMY03_START_ADDR,
-            .end_addr = DDR3_DUMMY03_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __TBTDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_TBTDECIMIQ3_START_ADDR,
-            .end_addr = DDR3_TBTDECIMIQ3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __DUMMY1_CHAN_ID,
-            .start_addr = DDR3_DUMMY13_START_ADDR,
-            .end_addr = DDR3_DUMMY13_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __TBTAMP_CHAN_ID,
-            .start_addr = DDR3_TBTAMP3_START_ADDR,
-            .end_addr = DDR3_TBTAMP3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __TBTPHA_CHAN_ID,
-            .start_addr = DDR3_TBTPHA3_START_ADDR,
-            .end_addr = DDR3_TBTPHA3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __TBTPOS_CHAN_ID,
-            .start_addr = DDR3_TBTPOS3_START_ADDR,
-            .end_addr = DDR3_TBTPOS3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __FOFBDECIMIQ_CHAN_ID,
-            .start_addr = DDR3_FOFBDECIMIQ3_START_ADDR,
-            .end_addr = DDR3_FOFBDECIMIQ3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __DUMMY2_CHAN_ID,
-            .start_addr = DDR3_DUMMY23_START_ADDR,
-            .end_addr = DDR3_DUMMY23_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __FOFBAMP_CHAN_ID,
-            .start_addr = DDR3_FOFBAMP3_START_ADDR,
-            .end_addr = DDR3_FOFBAMP3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __FOFBPHA_CHAN_ID,
-            .start_addr = DDR3_FOFBPHA3_START_ADDR,
-            .end_addr = DDR3_FOFBPHA3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __FOFBPOS_CHAN_ID,
-            .start_addr = DDR3_FOFBPOS3_START_ADDR,
-            .end_addr = DDR3_FOFBPOS3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __MONIT1AMP_CHAN_ID,
-            .start_addr = DDR3_MONIT1AMP3_START_ADDR,
-            .end_addr = DDR3_MONIT1AMP3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __MONIT1POS_CHAN_ID,
-            .start_addr = DDR3_MONIT1POS3_START_ADDR,
-            .end_addr = DDR3_MONIT1POS3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __MONITAMP_CHAN_ID,
-            .start_addr = DDR3_MONITAMP3_START_ADDR,
-            .end_addr = DDR3_MONITAMP3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
         {
             .id = __MONITPOS_CHAN_ID,
-            .start_addr = DDR3_MONITPOS3_START_ADDR,
-            .end_addr = DDR3_MONITPOS3_END_ADDR
+            .start_addr = ACQ3_START,
+            .end_addr = ACQ3_END
         },
     },
 };


### PR DESCRIPTION
The addresses that ended up being used for PostMortem acquisitions were outside of the 2GB DDR3 available in the board; this was observed as "corruption" for other acquisitions, since their data was overwritten (partially or fully).

In order to make the fix as simple as possible, we don't use the start_addr/end_addr macros from ddr3_map.h anymore, and simply write out our own, and use the same for all channels in a given module (we don't perform simultaneous acquisitions for different channels on the same module).