### PR TITLE
halcs_generic_udev: remove fofb-ioc launching.

### DIFF
--- a/src/apps/halcs_generic_udev/init-generic/share/halcs/scripts/run-fpga-program.sh
+++ b/src/apps/halcs_generic_udev/init-generic/share/halcs/scripts/run-fpga-program.sh
@@ -37,15 +37,6 @@ for i in $(seq 1 "${#HALCS_IDXS[@]}"); do
             START_PROGRAM="/usr/bin/systemctl --no-block start halcs-ioc@${HALCS_IDXS[$prog_inst]}.target"
             ;;
 
-        afcv4_fofb_ctrl*)
-            # Only start HALCSs for even-numbered instances, as there is no device for odd-numbered instances
-            if [ $((prog_inst%2)) -eq 0 ]; then
-                START_PROGRAM="/usr/bin/systemctl --no-block start fofb-ioc@${HALCS_IDXS[$prog_inst]}.service"
-            else
-                START_PROGRAM=""
-            fi
-            ;;
-
         afc-tim*)
             # Only start IOCs for even-numbered instances, as there is no device for odd-numbered instances
             if [ $((prog_inst%2)) -eq 0 ]; then


### PR DESCRIPTION
We are going to replace the FOFB IOC with a new one that doesn't use HALCS, so don't launch it here anymore.