### PR TITLE
halcsd: launch RFFE IOC using docker compose.

### DIFF
--- a/src/apps/halcs_generic_udev/init-generic/share/halcs/scripts/run-fpga-program.sh
+++ b/src/apps/halcs_generic_udev/init-generic/share/halcs/scripts/run-fpga-program.sh
@@ -15,6 +15,12 @@ FMC_NAMES=($@)
 # Get HALCS instances
 HALCS_IDXS=($(${DIR}/get-halcs-idxs.sh ${DEVICE_NUMBER}))
 
+HOST=$(hostname)
+case "$HOST" in
+  *rabpm-*) CRATE_NUMBER=$(echo "$HOST" | tr -d -c 0-9) ;;
+  *rabpmtl*) CRATE_NUMBER=21
+esac
+
 for i in $(seq 1 "${#HALCS_IDXS[@]}"); do
     prog_inst=$((i-1));
     case "${GATEWARE_NAME}" in
@@ -22,6 +28,9 @@ for i in $(seq 1 "${#HALCS_IDXS[@]}"); do
             case "${FMC_NAMES[$prog_inst]}" in
                 LNLS_FMC250M*)
                     START_PROGRAM="/usr/bin/systemctl --no-block start halcs-ioc@${HALCS_IDXS[$prog_inst]}.target"
+                    cd /opt/rffe-epics-ioc
+                    CRATE_NUMBER=$CRATE_NUMBER docker-compose up -d rffe-ioc-${HALCS_IDXS[$prog_inst]}
+                    cd -
                     ;;
                 LNLS_FMC130M*)
                     START_PROGRAM="/usr/bin/systemctl --no-block start halcs-ioc@${HALCS_IDXS[$prog_inst]}.target"

--- a/src/apps/halcsd/init/systemd/etc/systemd/system/halcs-fe@.service
+++ b/src/apps/halcsd/init/systemd/etc/systemd/system/halcs-fe@.service
@@ -4,7 +4,6 @@ After=network-online.target
 Wants=network-online.target
 After=malamute.service
 Requires=malamute.service
-PartOf=halcs@%i.target
 
 [Service]
 Environment=HALCS_LOG_DIR=/var/log/halcs
@@ -12,7 +11,3 @@ ExecStartPre=/bin/mkdir -p ${HALCS_LOG_DIR}
 ExecStart=/usr/local/bin/halcsd -f /usr/local/etc/halcs/halcs.cfg -n fe -t eth -i %i -b ipc:///tmp/malamute -l ${HALCS_LOG_DIR}
 WorkingDirectory=/usr/local/bin
 TimeoutStopSec=2
-
-[Install]
-RequiredBy=halcs-fe-ioc@%i.service
-WantedBy=halcs@%i.target

--- a/src/apps/halcsd/init/systemd/etc/systemd/system/halcs-fe@.service.in
+++ b/src/apps/halcsd/init/systemd/etc/systemd/system/halcs-fe@.service.in
@@ -4,7 +4,6 @@ After=network-online.target
 Wants=network-online.target
 After=malamute.service
 Requires=malamute.service
-PartOf=halcs@%i.target
 
 [Service]
 User=halcs
@@ -14,7 +13,3 @@ ExecStartPre=/bin/mkdir -p ${HALCS_LOG_DIR}
 ExecStart=@halcsd_CMAKE_INSTALL_FULL_BINDIR@/halcsd -f @halcsd_HALCS_INSTALL_FULL_SYSCONFDIR@/halcs.cfg -n fe -t eth -i %i -b ipc:///tmp/malamute -l ${HALCS_LOG_DIR}
 WorkingDirectory=@halcsd_CMAKE_INSTALL_FULL_BINDIR@
 TimeoutStopSec=2
-
-[Install]
-RequiredBy=halcs-fe-ioc@%i.service
-WantedBy=halcs@%i.target

--- a/src/apps/halcsd/init/systemd/etc/systemd/system/halcs@.target
+++ b/src/apps/halcsd/init/systemd/etc/systemd/system/halcs@.target
@@ -4,5 +4,3 @@ After=network-online.target
 Wants=network-online.target
 After=halcs-be@%i.service
 Wants=halcs-be@%i.service
-After=halcs-fe@%i.service
-Wants=halcs-fe@%i.service

--- a/src/apps/halcsd/init/systemd/etc/systemd/system/halcs@.target.in
+++ b/src/apps/halcsd/init/systemd/etc/systemd/system/halcs@.target.in
@@ -4,5 +4,3 @@ After=network-online.target
 Wants=network-online.target
 After=halcs-be@%i.service
 Wants=halcs-be@%i.service
-After=halcs-fe@%i.service
-Wants=halcs-fe@%i.service


### PR DESCRIPTION
To avoid quoting issues, don't use the START_PROGRAM variable, simply run the commands. We don't need to launch the service for the FMC130 version, since it's not in use.